### PR TITLE
Update Helm chart dependency repository URL

### DIFF
--- a/deployment templates/chart/bagetter/Chart.yaml
+++ b/deployment templates/chart/bagetter/Chart.yaml
@@ -28,5 +28,5 @@ sources:
 
 dependencies:
   - name: common
-    repository: http://bjw-s.github.io/helm-charts/
+    repository: https://bjw-s-labs.github.io/helm-charts
     version: 3.0.3


### PR DESCRIPTION
Summary of the changes (in less than 80 chars)

 * Update Helm chart dependency repository to latest URL

Addresses https://github.com/bagetter/BaGetter/issues/198
